### PR TITLE
autodocs: also exclude *.temp.* lexicons

### DIFF
--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -39,7 +39,7 @@ for await (const entry of entries) {
     const identifier = name === "main" ? id : `${id}.${name}`;
 
     // We don't want public-facing docs for unspecced endpoints
-    const containsUnspecced = identifier.toLowerCase().includes('unspecced');
+    const containsUnspecced = identifier.toLowerCase().includes('unspecced') || identifier.toLowerCase().includes('.temp.');
     const containsDeprecated = def.description?.toLowerCase().includes('deprecated') ?? false;
 
     if (containsUnspecced || containsDeprecated) {


### PR DESCRIPTION
I assume we don't want to include these, the same way we exclude `unspecced`.

The impacted endpoints are:

- `com.atproto.temp.checkSignupQueue`
- `com.atproto.temp.requestPhoneVerification`

cc: @pfrazee in case we do actually want this tmp signup stuff documented.

This PR doesn't include the results of doing a re-run of auto-generation; I assume that happens automatically, or can do as a follow-up.