### PR TITLE
Replace Langit with Skeetdeck

### DIFF
--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -270,11 +270,11 @@ const Users: User[] = [
     tags: ['client'],
   },
   {
-    title: 'Langit',
-    description: 'Web client for Bluesky',
+    title: 'Skeetdeck',
+    description: 'Deck-based web client for Bluesky',
     preview: require('./showcase/example-1.png'),
-    website: 'https://langit.pages.dev/',
-    author: 'https://bsky.app/profile/did:plc:qezk54orevt3dtm4ijcyadnq',
+    website: 'https://skeetdeck.pages.dev/',
+    author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
     tags: ['client'],
   },
   {

--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -274,8 +274,9 @@ const Users: User[] = [
     description: 'Deck-based web client for Bluesky',
     preview: require('./showcase/example-1.png'),
     website: 'https://skeetdeck.pages.dev/',
+    source: 'https://github.com/mary-ext/langit',
     author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
-    tags: ['client'],
+    tags: ['client', 'opensource'],
   },
   {
     title: 'vSky',


### PR DESCRIPTION
This pull request replaces Langit with Skeetdeck.

I took over development of Langit quite a while back, and it hasn't really been maintained much anymore, instead Skeetdeck is what's been born out of it.