### PR TITLE
Add skeetgen and bluesky-post-embeds

### DIFF
--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -766,6 +766,15 @@ const Users: User[] = [
     tags: ['othertools'],
   },
   {
+    title: 'skeetgen',
+    description: 'Archival tool for your Bluesky posts',
+    preview: require('./showcase/example-1.png'),
+    website: 'https://mary-ext.github.io/skeetgen/',
+    source: 'https://github.com/mary-ext/skeetgen',
+    author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
+    tags: ['othertools'],
+  },
+  {
     title: 'MTA Alerts',
     description: 'Bot for MTA Realtime Subway Alerts',
     preview: require('./showcase/example-1.png'),

--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -775,6 +775,15 @@ const Users: User[] = [
     tags: ['othertools'],
   },
   {
+    title: 'bluesky-post-embed',
+    description: 'Custom element for embedding Bluesky posts to other websites',
+    preview: require('./showcase/example-1.png'),
+    website: 'https://mary-ext.github.io/bluesky-post-embed/',
+    source: 'https://github.com/mary-ext/bluesky-post-embed',
+    author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
+    tags: ['othertools'],
+  },
+  {
     title: 'MTA Alerts',
     description: 'Bot for MTA Realtime Subway Alerts',
     preview: require('./showcase/example-1.png'),

--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -772,7 +772,7 @@ const Users: User[] = [
     website: 'https://mary-ext.github.io/skeetgen/',
     source: 'https://github.com/mary-ext/skeetgen',
     author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
-    tags: ['othertools'],
+    tags: ['othertools', 'opensource'],
   },
   {
     title: 'bluesky-post-embed',
@@ -781,7 +781,7 @@ const Users: User[] = [
     website: 'https://mary-ext.github.io/bluesky-post-embed/',
     source: 'https://github.com/mary-ext/bluesky-post-embed',
     author: 'https://bsky.app/profile/did:plc:ia76kvnndjutgedggx2ibrem',
-    tags: ['othertools'],
+    tags: ['othertools', 'opensource'],
   },
   {
     title: 'MTA Alerts',


### PR DESCRIPTION
This pull request adds my two other tools

- skeetgen, for archiving your Bluesky posts
- bluesky-post-embed, a custom element for embedding your Bluesky posts to another website.