### PR TITLE
Fix wrong parameter name

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -46,7 +46,7 @@ Create an authentication session with your username and password.
       service: 'https://bsky.social'
     })
     await agent.login({
-      username: 'example.com',
+      identifier: 'example.com',
       password: 'hunter2'
     })
     ```

--- a/docs/tutorials/creating-a-post.mdx
+++ b/docs/tutorials/creating-a-post.mdx
@@ -33,7 +33,7 @@ Each post requires these fields: `text` and `createdAt` (a timestamp).
       service: 'https://bsky.social'
     })
     await agent.login({
-      username: 'example.com',
+      identifier: 'example.com',
       password: 'hunter2'
     })
 


### PR DESCRIPTION
I encountered an error when I run a code in doc.

> XRPCError: Input must have the property “identifier"

TypeSciprt SDK’s `BskyAgent#login` requires `identifier` not `username`.
