### PR TITLE
fixed endpoint(spell mistake)

### DIFF
--- a/docs/api/com-atproto-server-create-account.api.mdx
+++ b/docs/api/com-atproto-server-create-account.api.mdx
@@ -30,7 +30,7 @@ import TabItem from "@theme/TabItem";
 
 <MethodEndpoint
   method={"post"}
-  path={"/com.atproto.server.createAccount"}
+  path={"com.atproto.server.createAccount"}
 >
   
 </MethodEndpoint>


### PR DESCRIPTION
<img width="556" alt="スクリーンショット 2024-02-11 0 56 54" src="https://github.com/bluesky-social/bsky-docs/assets/32926719/3796663a-43b5-4104-929a-079e4dfc3513">


Thus, we found a problem with duplicate /. This makes it impossible to access the API just by copying it, so we wanted to fix it!