### PR TITLE
fix openapi generation

### DIFF
--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -43,7 +43,8 @@ for await (const entry of entries) {
     const containsDeprecated = def.description?.toLowerCase().includes('deprecated') ?? false;
 
     if (containsUnspecced || containsDeprecated) {
-      break;
+      console.log("skipping: " + identifier)
+      continue;
     }
 
     switch (def.type) {

--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -40,7 +40,7 @@ for await (const entry of entries) {
 
     // We don't want public-facing docs for unspecced endpoints
     const containsUnspecced = identifier.toLowerCase().includes('unspecced') || identifier.toLowerCase().includes('.temp.');
-    const containsDeprecated = def.description?.toLowerCase().includes('deprecated') ?? false;
+    const containsDeprecated = def.description?.toLowerCase().startsWith('deprecated') ?? false;
 
     if (containsUnspecced || containsDeprecated) {
       console.log("skipping: " + identifier)


### PR DESCRIPTION
The core fix here is to skip per-identifier (`continue`), not the remainder of a file (`break`) in a loop.

Also makes the deprecation skipping logic more conservative, as we have some descriptions that mention possible deprecation, but it hasn't happened yet, and we should continue to include the docs.

I tested running generation locally, but didn't commit the spec file update in this PR.

@rdmurphy I think we forked this code from you originally? So you might be interested in this patch ("continue" vs "break")