### PR TITLE
replace openapi endpoint examples

### DIFF
--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -101,12 +101,16 @@ const api: OpenAPIV3_1.Document = {
   },
   servers: [
     {
-      url: "https://bsky.social/xrpc/",
-      description: "AT Protocol PDS XRPC server",
+      url: "https://public.api.bsky.app/xrpc/",
+      description: "Bluesky AppView (Public, No Auth)",
     },
     {
-      url: "https://api.bsky.app/xrpc/",
-      description: "AT Protocol AppView XRPC server",
+      url: "https://pds.example.org/xrpc/",
+      description: "Example atproto PDS (Authenticated)",
+    },
+    {
+      url: "https://bsky.network/xrpc/",
+      description: "Bluesky Relay (Public, No Auth)",
     },
   ],
   paths,


### PR DESCRIPTION
I think the generated docs will be less confusing with these examples given.

Eg, there is currently little or no reason to ever make API requests to `api.bsky.app` from apps/clients. Authenticated requests should go to the PDS (and get proxied), and un-authenticated requests should go to `public.api.bsky.app`.