### PR TITLE
chore(firehose.mdx): correct variable name

### DIFF
--- a/docs/advanced-guides/firehose.mdx
+++ b/docs/advanced-guides/firehose.mdx
@@ -28,7 +28,7 @@ provider for the `com.atproto.sync.subscribeRepos` endpoint:
 <Tabs groupId="sdk">
   <TabItem value="go" label="Go">
     ```go
-    url := "https://bsky.network/xrpc/com.atproto.sync.subscribeRepos"
+    uri := "https://bsky.network/xrpc/com.atproto.sync.subscribeRepos"
     con, _, err := websocket.DefaultDialer.Dial(uri, http.Header{})
     ```
   </TabItem>


### PR DESCRIPTION
make the firehose connection example use consistent naming for the URL variable.