### PR TITLE
API service location and auth context; and guide

### DIFF
--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -47,22 +47,22 @@ for await (const entry of entries) {
       continue;
     }
 
-    let descriptionPrefix = "To learn more about calling atproto API endpoints like this one, see the [/docs/advanced-guides/api-services-auth](API Services and Auth) guide."
+    let descriptionPrefix = "*To learn more about calling atproto API endpoints like this one, see the [API Hosts and Auth](/docs/advanced-guides/api-directory) guide.*"
 
     if (id.startsWith("tools.ozone.")) {
-      descriptionPrefix = "This is endpoint is part of the [Ozone moderation service](https://ozone.tools/) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the Ozone instance indicated by the DID in the service proxying header. Admin authenentication may also be possible, with request sent directly to the Ozone instance.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the [Ozone moderation service](https://ozone.tools/) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the Ozone instance indicated by the DID in the service proxying header. Admin authenentication may also be possible, with request sent directly to the Ozone instance.*\n\n" + descriptionPrefix
     } else if (id.startsWith("chat.bsky.")) {
-      descriptionPrefix = "This is endpoint is part of the Bluesky Chat (DMs) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the single central chat service by setting the appropriate service DID (`did:web:api.bsky.chat`) in the service proxying header.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the Bluesky Chat (DMs) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the single central chat service by setting the appropriate service DID (`did:web:api.bsky.chat`) in the service proxying header.*\n\n" + descriptionPrefix
     } else if (id.startsWith("com.atproto.admin.")) {
-      descriptionPrefix = "This is endpoint is part of the atproto PDS management APIs. Requests usually require admin authentication and are made directly to the PDS instance.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the atproto PDS management APIs. Requests usually require admin authentication and are made directly to the PDS instance.*\n\n" + descriptionPrefix
     } else if (id.startsWith("com.atproto.sync.")) {
-      descriptionPrefix = "This is endpoint is part of the atproto repository synchronization APIs. Requests usually do not require authentication, and can be made to PDS intances or Relay instances.\n\n" + descriptionPrefix
+      descriptionPrefix = "This endpoint is part of the atproto repository synchronization APIs. Requests usually do not require authentication, and can be made to PDS intances or Relay instances.*\n\n" + descriptionPrefix
     } else if (id.startsWith("com.atproto.repo.")) {
-      descriptionPrefix = "This is endpoint is part of the atproto PDS repository management APIs. Requests usually require authentication (unlike the `com.atproto.sync.*` endpoints), and are made directly to the user's own PDS instance.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the atproto PDS repository management APIs. Requests usually require authentication (unlike the `com.atproto.sync.*` endpoints), and are made directly to the user's own PDS instance.*\n\n" + descriptionPrefix
     } else if (id.startsWith("com.atproto.server.")) {
-      descriptionPrefix = "This is endpoint is part of the atproto PDS server and account management APIs. Requests often require authentication and are made directly to the user's own PDS instance.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the atproto PDS server and account management APIs. Requests often require authentication and are made directly to the user's own PDS instance.*\n\n" + descriptionPrefix
     } else if (id.startsWith("app.bsky.")) {
-      descriptionPrefix = "This is endpoint is part of the Bluesky application Lexicon APIs (`app.bsky.*`). Public endpoints which don't require authentication can be made directly against the public Bluesky AppView API: https://public.api.bsky.app. Authenticated requests are usually made to the user's PDS, with automatic service proxying. Authenticated requests can be used for both public and non-public endpoints.\n\n" + descriptionPrefix
+      descriptionPrefix = "*This endpoint is part of the Bluesky application Lexicon APIs (`app.bsky.*`). Public endpoints which don't require authentication can be made directly against the public Bluesky AppView API: https://public.api.bsky.app. Authenticated requests are usually made to the user's PDS, with automatic service proxying. Authenticated requests can be used for both public and non-public endpoints.*\n\n" + descriptionPrefix
     }
 
     switch (def.type) {

--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -84,7 +84,7 @@ for await (const entry of entries) {
             }
           }
           // @ts-ignore FIXME: Also confused about ArraySchemaObject
-          paths[`/${id}`] = { post };
+          paths[`/xrpc/${id}`] = { post };
         }
         break;
       }
@@ -100,7 +100,7 @@ for await (const entry of entries) {
             }
           }
           // @ts-ignore FIXME: Also confused about ArraySchemaObject
-          paths[`/${id}`] = { get };
+          paths[`/xrpc/${id}`] = { get };
         }
         break;
       }
@@ -131,20 +131,7 @@ const api: OpenAPIV3_1.Document = {
     description: "This section contains HTTP API reference docs for Bluesky and AT Protocol lexicons. Generate a bearer token to test API calls directly from the docs.",
     version: "0.0.0", // This will be a living document for now, so no versioning yet
   },
-  servers: [
-    {
-      url: "https://public.api.bsky.app/xrpc",
-      description: "Bluesky AppView (Public, No Auth)",
-    },
-    {
-      url: "https://pds.example.org/xrpc",
-      description: "Example atproto PDS (Authenticated)",
-    },
-    {
-      url: "https://bsky.network/xrpc",
-      description: "Bluesky Relay (Public, No Auth)",
-    },
-  ],
+  servers: [],
   paths,
   components,
   tags: Array.from(tagNames).map((name) => ({ name })),

--- a/atproto-openapi-types/main.ts
+++ b/atproto-openapi-types/main.ts
@@ -47,6 +47,24 @@ for await (const entry of entries) {
       continue;
     }
 
+    let descriptionPrefix = "To learn more about calling atproto API endpoints like this one, see the [/docs/advanced-guides/api-services-auth](API Services and Auth) guide."
+
+    if (id.startsWith("tools.ozone.")) {
+      descriptionPrefix = "This is endpoint is part of the [Ozone moderation service](https://ozone.tools/) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the Ozone instance indicated by the DID in the service proxying header. Admin authenentication may also be possible, with request sent directly to the Ozone instance.\n\n" + descriptionPrefix
+    } else if (id.startsWith("chat.bsky.")) {
+      descriptionPrefix = "This is endpoint is part of the Bluesky Chat (DMs) APIs. Requests usually require authentication, are directed to the user's PDS intance, and proxied to the single central chat service by setting the appropriate service DID (`did:web:api.bsky.chat`) in the service proxying header.\n\n" + descriptionPrefix
+    } else if (id.startsWith("com.atproto.admin.")) {
+      descriptionPrefix = "This is endpoint is part of the atproto PDS management APIs. Requests usually require admin authentication and are made directly to the PDS instance.\n\n" + descriptionPrefix
+    } else if (id.startsWith("com.atproto.sync.")) {
+      descriptionPrefix = "This is endpoint is part of the atproto repository synchronization APIs. Requests usually do not require authentication, and can be made to PDS intances or Relay instances.\n\n" + descriptionPrefix
+    } else if (id.startsWith("com.atproto.repo.")) {
+      descriptionPrefix = "This is endpoint is part of the atproto PDS repository management APIs. Requests usually require authentication (unlike the `com.atproto.sync.*` endpoints), and are made directly to the user's own PDS instance.\n\n" + descriptionPrefix
+    } else if (id.startsWith("com.atproto.server.")) {
+      descriptionPrefix = "This is endpoint is part of the atproto PDS server and account management APIs. Requests often require authentication and are made directly to the user's own PDS instance.\n\n" + descriptionPrefix
+    } else if (id.startsWith("app.bsky.")) {
+      descriptionPrefix = "This is endpoint is part of the Bluesky application Lexicon APIs (`app.bsky.*`). Public endpoints which don't require authentication can be made directly against the public Bluesky AppView API: https://public.api.bsky.app. Authenticated requests are usually made to the user's PDS, with automatic service proxying. Authenticated requests can be used for both public and non-public endpoints.\n\n" + descriptionPrefix
+    }
+
     switch (def.type) {
       case "array":
         components.schemas![identifier] = convertArray(id, name, def);
@@ -58,6 +76,13 @@ for await (const entry of entries) {
         const post = await convertProcedure(id, name, def);
 
         if (post) {
+          if (descriptionPrefix) {
+            if (post.description) {
+              post.description = descriptionPrefix + "\n\n" + def.description
+            } else {
+              post.description = descriptionPrefix
+            }
+          }
           // @ts-ignore FIXME: Also confused about ArraySchemaObject
           paths[`/${id}`] = { post };
         }
@@ -67,6 +92,13 @@ for await (const entry of entries) {
         const get = await convertQuery(id, name, def);
 
         if (get) {
+          if (descriptionPrefix) {
+            if (def.description) {
+              get.description = descriptionPrefix + "\n\n" + def.description
+            } else {
+              get.description = descriptionPrefix
+            }
+          }
           // @ts-ignore FIXME: Also confused about ArraySchemaObject
           paths[`/${id}`] = { get };
         }

--- a/docs/advanced-guides/api-directory.mdx
+++ b/docs/advanced-guides/api-directory.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 18
+---
+
+# API Hosts and Auth
+
+Lexicon API definitions do not always indicate which network services implement the endpoint, and whether auth is required when making HTTP requests. This guide describes the most common API request patterns, and lists the specific hostnames for Bluesky-operated services.
+
+As a reminder, the Bluesky application is built on atproto, a decentralized social web protocol. Unlike some social media platforms, there is not one centralized API. More like the classic web, there can be multiple independent service providers and account hosts.
+
+
+## Common Request Types
+
+Most client API requests fall in one of a few categories.
+
+**Data record writes, and account management:** all public data in the network exists as records in user repositories on their PDS instance, which means all data creation, update, and deletion, for all applications, involves repository API calls to the PDS. This includes things like creating posts, updating profiles, following and unfollowing, etc. These actions require authentication, are made to the user's PDS instance (which needs to be resolved or discovered as part of creating an auth session), and usually involve the `com.atproto.*` Lexicons. Account management requests, such as updating the account handle, also go directly to the PDS. See [PDS Entryway](/docs/advanced-guides/entryway) for the distinction between PDS instances and the "entryway" service.
+
+**Authenticated Bluesky app requests:** API requests relevant to the Bluesky Social app (`app.bsky.*` Lexicon endpoints) are routed to a Bluesky AppView. This includes reads, as well as private data writes which don't involve repository records, such as "mutes". In the current atproto architecture, these requests all go through the user PDS instance, and get proxied to the correct service. For most services, the proxying is controlled by the `atproto-proxy` header, but as of Fall 2024 this is still configured server-side for the Bluesky AppView, and the `atproto-proxy` is not required.
+
+**Public Bluesky app requests:** many Bluesky Lexicon endpoints are public, and do not require authentication. These endpoints can be made directly against the Bluesky AppView, preferably via the `https://public.api.bsky.app` hostname, which includes additional caching.
+
+Note that it is perfectly fine for authenticated clients to use authenticated requests to hit public Bluesky API endpoints. It is often simpler for authenticated clients to make all requests via the PDS and proxying, instead of juggling multiple API client connections.
+
+**Firehose:** data updates from the entire network can be streamed over a WebSocket using the `com.atproto.sync.subscribeRepos` Lexicon endpoint. This endpoint does not require auth, and can be made to individual PDS instances (for data just from that PDS), or to a Relay to receive updates from the entire network.
+
+**Other Proxied App Requests:** for example, the `chat.bsky.*` centralized chat/DM APIs, or the `tools.ozone.*` moderation APIs. These are generally authenticated, routed via the PDS, and use service proxying to route to the relevant service instance.
+
+
+## Other Request Types
+
+There are a few other patterns of API requests.
+
+**Fetching Content from Original PDS:** sometimes a service or tool needs to request blobs, account status, or repository directly from the original PDS. These are usually un-authenticated requests, and use `com.atproto.*` Lexicons. The specific PDS hostname needs to be resolved from the relevant account's identity (DID document).
+
+**Inter-Service Requests:** most clients can rely on PDS instances to handle service request proxying, but PDS implementations themselves need to handle those requests. Service DIDs need to be resolved to specific HTTPS hostnames, and service auth tokens generated and signed. Receiving services need to decode and verify the auth token.
+
+**Admin Auth:** used for a few specific operational tasks, like administering PDS instances, or bulk operations against Ozone moderation services. Requests are made directly to the relevant service, using fixed/static Bearer tokens.
+
+**Bulk Data Requests:** for example, when backfilling existing data from the network in to a new service instance, like an AppView instance. It is possible to distribute load across all the PDS instances, or centralize requests to a Relay instance, which may have a faster network connection.
+
+
+## Bluesky Services
+
+This table summarizes the hostnames for Bluesky-operated atproto network services.
+
+| Type | Host URL | Service DID |
+| ---- | --- | ----------- |
+| Relay | `https://bsky.network` | n/a |
+| Entryway | `https://bsky.social` | n/a |
+| PDS Instances | `https://<NAME>.<REGION>.host.bsky.network` | n/a |
+| bsky AppView | `https://api.bsky.app` | TODO |
+| Chat / DMs | `https://api.bsky.chat` | `did:web:api.bsky.chat#bsky_chat` |
+| Ozone / Moderation | `https://mod.bsky.app` | `did:plc:ar7c4by46qjdydhdevvrndac#atproto_labeler` |
+


### PR DESCRIPTION
A common source of dev confusion with atproto/bsky is which hosts to make different API requests against, and whether authentication is required.

This PR tries to address this with a new guide article which summarizes the common patterns, and namespace-specific boilerplate text in the HTTP API reference docs which talk about host options and whether auth is required (and links to the guide article).

This PR doesn't include re-running OpenAPI spec generation or MDX generation, because those steps would result in merge conflicts with the automated daily updates.

Here it what it looks like rendered ("This is endpoint is [...]" typo has been fixed):

![2024-10-02T00:39:18,059497964-07:00](https://github.com/user-attachments/assets/f9ed99b1-ea40-44c1-8fa5-5e0ff0a0827b)
