### PR TITLE
rip out API explorer and code snippets

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,6 +163,8 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      // disable openapi language snippets
+      languageTabs: [],
       algolia: {
         appId: 'T5MN80JFZF',
         // Public API key: it is safe to commit it

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,3 +77,8 @@
   margin-right: 10px;
   transition: all 0.3s ease;
 }
+
+/* disable generated OpenAPI code explorer (right panel) */
+.openapi-right-panel__container {
+  visibility: hidden;
+}


### PR DESCRIPTION
This is the "right hand column" on the HTTP API reference docs.

These snippets are great for devex in theory, but are currently often wrong and misleading for atproto+bsky APIs. Part of the problem is that different API requests need to be routed to different services (or possibly use service proxying headers to the user's PDS), and may require auth. Devs frequently hit "HTTP 405 Method Not Allowed" errors when trying to call endpoints against the wrong service backend. The confusion is not worth the upside for the small number of endpoints which *do* work correctly (eg, don't require auth, are against the `api.bsky.app` host specifically.

The medium-term plan here is to have an atproto-specific Lexicon aggregation and docs site which can provide this kind of code snippet and live exploration functionality in a more protocol-native way, including snippets that use actual SDKs, and possibly even login with OAuth to make authenticated requests.

For now, ripping out this feature should reduce confusion. Pairs with https://github.com/bluesky-social/bsky-docs/pull/198, which adds docs about how to make requests.