### PR TITLE
Update get-started.mdx

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -40,9 +40,9 @@ Create an authentication session with your username and password.
 <Tabs groupId="sdk">
   <TabItem value="ts" label="Typescript">
     ```typescript
-    import { BskyAgent } from '@atproto/api'
+    import { AtpAgent } from '@atproto/api'
 
-    const agent = new BskyAgent({
+    const agent = new AtpAgent({
       service: 'https://bsky.social'
     })
     await agent.login({


### PR DESCRIPTION
- Replaced deprecated `BskyAgent` import with `AtpAgent`

```
'BskyAgent' is deprecated.ts(6385)
bsky-agent.d.ts(2, 5): The declaration was marked as deprecated here.
```