### PR TITLE
BskyAgent -> AtpAgent in docs

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -40,9 +40,9 @@ Create an authentication session with your username and password.
 <Tabs groupId="sdk">
   <TabItem value="ts" label="Typescript">
     ```typescript
-    import { BskyAgent } from '@atproto/api'
+    import { AtpAgent } from '@atproto/api'
 
-    const agent = new BskyAgent({
+    const agent = new AtpAgent({
       service: 'https://bsky.social'
     })
     await agent.login({


### PR DESCRIPTION
I noticed that the `BskyAgent` was deprecated when I went to use the TypeScript package, and recommended that I use the `AtpAgent` instead

Just updating the docs that I was using that lead me to try the `BskyAgent` initially! I assume there are other instances of this that I will try to update as I go along