### PR TITLE
Update the Bot's starter template code example to use CredentialSession

### DIFF
--- a/docs/starter-templates/bots.mdx
+++ b/docs/starter-templates/bots.mdx
@@ -31,21 +31,25 @@ BLUESKY_PASSWORD=
 The below script will post 🙂 every three hours.
 
 ```TypeScript
-import { BskyAgent } from '@atproto/api';
+import { Agent, CredentialSession } from '@atproto/api';
 import * as dotenv from 'dotenv';
 import { CronJob } from 'cron';
 import * as process from 'process';
 
 dotenv.config();
 
-// Create a Bluesky Agent 
-const agent = new BskyAgent({
-    service: 'https://bsky.social',
-  })
+// Create a new Credential Session
+const session = new CredentialSession(new URL('https://bsky.social'));
+
+// Create an Agent using the Credential Session 
+const agent = new Agent(session);
 
 
 async function main() {
-    await agent.login({ identifier: process.env.BLUESKY_USERNAME!, password: process.env.BLUESKY_PASSWORD!})
+    await session.login({
+        identifier: process.env.BLUESKY_USERNAME!,
+        password: process.env.BLUESKY_PASSWORD!
+    });
     await agent.post({
         text: "🙂"
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript-plugin-css-modules": "^3.4.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": "18.x"
       }
     },
     "node_modules/@algolia/autocomplete-core": {


### PR DESCRIPTION
Use `CredentialSession` with the `Agent` class to, well, create a new agent as per recommend by the atproto library. Currently `BskyAgent` & `AtpAgent` are both deprecated (AtpAgent is soon to be deprecated)