### PR TITLE
chore: replace deprecated BskyAgent with AtpAgent

### DIFF
--- a/docs/starter-templates/bots.mdx
+++ b/docs/starter-templates/bots.mdx
@@ -31,7 +31,7 @@ BLUESKY_PASSWORD=
 The below script will post 🙂 every three hours.
 
 ```TypeScript
-import { BskyAgent } from '@atproto/api';
+import { AtpAgent } from '@atproto/api';
 import * as dotenv from 'dotenv';
 import { CronJob } from 'cron';
 import * as process from 'process';
@@ -39,7 +39,7 @@ import * as process from 'process';
 dotenv.config();
 
 // Create a Bluesky Agent 
-const agent = new BskyAgent({
+const agent = new AtpAgent({
     service: 'https://bsky.social',
   })
 

--- a/docs/starter-templates/clients.mdx
+++ b/docs/starter-templates/clients.mdx
@@ -43,9 +43,9 @@ Next, let's make a new file called `src/lib/api.ts` and add the following code:
 
 ```TypeScript
 // src/lib/api.ts
-import { BskyAgent } from "@atproto/api";
+import { AtpAgent } from "@atproto/api";
 
-export const agent = new BskyAgent({
+export const agent = new AtpAgent({
   // App View URL
   service: "https://api.bsky.app",
   // If you were making an authenticated client, you would


### PR DESCRIPTION
The usage of `BskyAgent` is now deprecated in the `@atproto/api` package, and the recommended approach is to use `AtpAgent` for building Bluesky client applications. 

This PR updates the code example to use `AtpAgent`, ensuring compatibility with the latest standards.