### PR TITLE
Properly import client_utils for TextBuilder

### DIFF
--- a/docs/tutorials/creating-a-post.mdx
+++ b/docs/tutorials/creating-a-post.mdx
@@ -164,9 +164,9 @@ Learn about how mentions and links work under the hood with the [Link, mentions,
   Use TextBuilder to construct a post with mentions and links.
 
     ```python
-    from atproto import TextBuilder
+    from atproto import client_utils
 
-    tb = TextBuilder()
+    tb = client_utils.TextBuilder()
     tb.text('✨ example mentioning ')
     tb.mention('atproto.com', 'did:plc:ewvi7nxzyoun6zhxrhs64oiz')
     tb.text(' to share the URL ')


### PR DESCRIPTION
The documentation now matches the necessary import for `TextBuilder` for Python. See [`TextBuilder`](https://atproto.blue/en/latest/atproto_client/utils/text_builder.html#atproto_client.utils.text_builder.TextBuilder) documentation for AT Protocol SDK.

Fixes #265 