### PR TITLE
Add BlueSky Multiple PLC Relay to showcase

### DIFF
--- a/src/data/users.tsx
+++ b/src/data/users.tsx
@@ -1242,6 +1242,16 @@ const Users: User[] = [
     author: 'https://bsky.app/profile/did:plc:aeu4zvcwmdk774qmqcyed5sa',
     tags: ['othertools', 'opensource'],
   },
+  {
+    title: 'BlueSky Multiple PLC Relay',
+    description: 'This project provides a simple relay/proxy service to allow validate DIDs on multiple PLC directories.',
+    preview: require('./showcase/example-1.png'),
+    website: 'https://github.com/eddieoz/bsky-plc-relay',
+    source: 'https://github.com/eddieoz/bsky-plc-relay',
+    author: 'https://bsky.app/profile/did:plc:f6beqf2stqdl34t5nr4mlodp',
+    tags: ['othertools', 'opensource', 'protocol'],
+  },
+
 
 ]
 


### PR DESCRIPTION
This project provides a simple relay/proxy service for the [PLC (Placeholder) directory](https://web.plc.directory/) used by [Bluesky](https://bsky.social/about/). It allows you to self-host a relay to forward requests to a central PLC server, as well as multiple distributed read endpoints. By doing so, you can offload some operations, maintain local copies of accounts, and ultimately reduce reliance on a single central PLC endpoint to validate DIDs.