### PR TITLE
specified refresh token requirement in com.atproto.server.deleteSession

### DIFF
--- a/docs/api/com-atproto-server-delete-session.api.mdx
+++ b/docs/api/com-atproto-server-delete-session.api.mdx
@@ -40,7 +40,7 @@ import Heading from "@theme/Heading";
 
 *To learn more about calling atproto API endpoints like this one, see the [API Hosts and Auth](/docs/advanced-guides/api-directory) guide.*
 
-Delete the current session. Requires auth.
+Delete the current session. Requires auth using the 'refreshJwt' token (not the 'accessJwt' token).
 
 <ParamsDetails
   parameters={undefined}


### PR DESCRIPTION
https://docs.bsky.app/docs/api/com-atproto-server-delete-session
unclear information about auth requirement, now specifies the requirement of 'refreshJwt'