### PR TITLE
Add `app.bsky.feed.threadgate#followerRule` to thread-gates.mdx

### DIFF
--- a/docs/tutorials/thread-gates.mdx
+++ b/docs/tutorials/thread-gates.mdx
@@ -13,6 +13,7 @@ The available rules are:
 
 - **app.bsky.feed.threadgate#mentionRule**: Allow replies from actors mentioned in your post.
 - **app.bsky.feed.threadgate#followingRule**: Allow replies from actors you follow.
+- **app.bsky.feed.threadgate#followerRule**: Allow replies from actors following you.
 - **app.bsky.feed.threadgate#listRule**: Allow replies from actors on a list.
 
 A thread gate may have up to 5 rules.


### PR DESCRIPTION
I'm working on threadgate related things and noticed the docs had the following rule, but were missing the follower rule. This is a quick PR that lists it with the rest of them