### PR TITLE
Fix typo and add link in rate limits doc

### DIFF
--- a/docs/advanced-guides/rate-limits.md
+++ b/docs/advanced-guides/rate-limits.md
@@ -29,7 +29,7 @@ The limit is 5,000 points per hour and 35,000 points per day. Points are counted
 
 Under this system, an account may create at most 1,666 records per hour and 11,666 records per day. That means an account can like up to 1,666 records in one hour with no problem. We took the most active human users on the network into account when we set this threshold (you surpassed our expectations!).
 
-Note that moderation systems and other application-specific limits may apply, or that services may degrade in some situations. For example, following other users and "liking" content both count as interactions in the in the Bluesky app, and bulk or spammy interactions are against the Community Guidelines.
+Note that moderation systems and other application-specific limits may apply, or that services may degrade in some situations. For example, following other users and "liking" content both count as interactions in the Bluesky app, and bulk or spammy interactions are against the Community Guidelines.
 
 
 ## Hosted Account (PDS) Limits

--- a/docs/advanced-guides/rate-limits.md
+++ b/docs/advanced-guides/rate-limits.md
@@ -29,7 +29,7 @@ The limit is 5,000 points per hour and 35,000 points per day. Points are counted
 
 Under this system, an account may create at most 1,666 records per hour and 11,666 records per day. That means an account can like up to 1,666 records in one hour with no problem. We took the most active human users on the network into account when we set this threshold (you surpassed our expectations!).
 
-Note that moderation systems and other application-specific limits may apply, or that services may degrade in some situations. For example, following other users and "liking" content both count as interactions in the Bluesky app, and bulk or spammy interactions are against the Community Guidelines.
+Note that moderation systems and other application-specific limits may apply, or that services may degrade in some situations. For example, following other users and "liking" content both count as interactions in the Bluesky app, and bulk or spammy interactions are against the [Community Guidelines](https://bsky.social/about/support/community-guidelines).
 
 
 ## Hosted Account (PDS) Limits


### PR DESCRIPTION
This PR removes a repeated instance of `in the` in the rate limits doc.

Also, it might be helpful to some readers to add a link to the Community Guidelines when they're referenced, so a separate commit adds that.