### PR TITLE
Remove `iss` from DPoP resource request requirements in oauth guide doc

### DIFF
--- a/docs/advanced-guides/oauth-client.md
+++ b/docs/advanced-guides/oauth-client.md
@@ -188,7 +188,6 @@ When making DPoP requests to PDS endpoints:
 
 - same JWT header fields as above
 - same JWT body fields as above, plus:
-    - `iss`: authorization server issuer
     - `ath`: hash of the access token, using the same mechanism as the `S256` PKCE challenge hash
 - JWT string in the `DPoP` HTTP header
 - access token in the `Authorization` HTTP header, with type `DPoP` (so header looks like `Authorization: DPoP <token>`)


### PR DESCRIPTION
see https://github.com/bluesky-social/cookbook/issues/23