### PR TITLE
remove out-of-date language about non-Bluesky Lexicons

### DIFF
--- a/docs/advanced-guides/custom-schemas.mdx
+++ b/docs/advanced-guides/custom-schemas.mdx
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 The AT Protocol, and specifically Lexicon, provides a toolkit for creating decentralization social applications. Lexicon is meant to be a social coordination tool. It's an explicit way to announce the schema that some data adheres to and compare it against the schemas that your application understands.
 
-The Bluesky microblogging application uses schemas defined in the `app.bsky.*` namespace. We're excited for other applications to emerge on atproto as well. Right now, we artificially prevent non-Bluesky records from being created by our PDSs. However, we'll be lifting that limitation soon.
+The Bluesky microblogging application uses schemas defined in the `app.bsky.*` namespace. Applications are welcome to build upon these schemas, or define their own in independent namespaces.
 
 When creating new lexicons, you *must* identity them under a domain name that you control. 
 

--- a/docs/advanced-guides/entryway.md
+++ b/docs/advanced-guides/entryway.md
@@ -4,7 +4,7 @@ sidebar_position: 14
 
 # PDS Entryway
 
-Bluesky runs many PDSs. Each PDS runs as a completely separate service in the network with its own identity. They federate with the rest of the network in the exact same manner that a non-Bluesky PDS would. These PDSs have hostnames such as `morel.us-east.host.bsky.network`.
+Bluesky runs many PDSs. Each PDS runs as a completely separate service in the network with its own identity. They federate with the rest of the network in the exact same manner that a non-Bluesky PDS does. These PDSs have hostnames such as `morel.us-east.host.bsky.network`.
 
 However, the user-facing concept for Bluesky's "PDS Service" is simply `bsky.social`. This is reflected in the provided subdomain that users on a Bluesky PDS have access to (i.e. their default handle suffix), as well as the hostname that they may provide at login in order to route their login request to the correct service. A user should not be expected to understand or remember the specific host that their account is on.
 


### PR DESCRIPTION
Was pointed out in-app here: https://bsky.app/profile/somemetatags.owens.dev/post/3lusbfgsba22x