### PR TITLE
post guide: python 'datetime' is always installed

### DIFF
--- a/docs/advanced-guides/posts.md
+++ b/docs/advanced-guides/posts.md
@@ -24,7 +24,7 @@ Bluesky posts are repository records with the [Lexicon type](https://github.com/
 
 Each post requires these fields: `text` and `createdAt` (a timestamp).
 
-This script below will create a simple post with just a text field and a timestamp. You'll need the `datetime` package installed.
+This script below will create a simple post with just a text field and a timestamp.
 
 ```python
 import json


### PR DESCRIPTION
Closes: https://github.com/bluesky-social/bsky-docs/issues/372