### PR TITLE
fix incorrect description of replies as one-dimensional array

### DIFF
--- a/docs/tutorials/viewing-threads.mdx
+++ b/docs/tutorials/viewing-threads.mdx
@@ -51,11 +51,7 @@ interface ThreadViewPost {
 
 Here, the `post` is the "root" - whose URI you provided the `getPostThread`
 method. The `parent` is a nested tree of ancestors (if any), and the `replies`
-is a one-dimentional array of replies (if any).
-
-Because `replies` is one-dimensional, to facilitate the construction of a tree
-from this data, each reply object in the array contains references to its
-immediate parent (ancestor) and immediate child (descendent).
+is a recursive tree of replies (if any). Each `ThreadViewPost` in `replies` may itself contain further `replies`, forming a tree that can be traversed by recursing into each reply.
 
 ### The `depth` and `parentHeight` parameters
 


### PR DESCRIPTION
The "Viewing Threads" tutorial incorrectly states that `replies` is a one-dimensional array, and that tree construction requires following `parent`/child references on each reply object.

In fact, `replies` on a `ThreadViewPost` is itself a recursive array of `ThreadViewPost | NotFoundPost | BlockedPost` objects. Each reply may contain its own `replies`, forming a tree directly. No manual tree reconstruction from a flat array is needed.

Fixes #299