### PR TITLE
rate limits: document label limits

### DIFF
--- a/docs/advanced-guides/rate-limits.md
+++ b/docs/advanced-guides/rate-limits.md
@@ -80,3 +80,11 @@ The Bluesky-operated Relay (`https://bsky.network`) applies the following limits
 
 These limits are intended to limit abuse while still allowing open federation. If the default limits cause problems for growing PDS instances, please reach out and they can be raised.
 
+
+## Label Limits
+
+The Bluesky AppView applies the following limits to all labeling services (eg, Ozone moderation instances):
+
+- 5 per second
+- 5,000 per hour
+- 50,000 per day (24 hour period)


### PR DESCRIPTION
These are the current values, which have not changed since March 2024.

The copy text here isn't super informative, and open to improvements. Though this entire page is pretty bare-bones, and we don't have good resources or debugging tools to link folks to about label ingest specifically.