### PR TITLE
Docs: Emphasize that readSessionFromDisk and writeSessionToDisk helpers aren't provided by the API

### DIFF
--- a/docs/starter-templates/bots.mdx
+++ b/docs/starter-templates/bots.mdx
@@ -81,7 +81,7 @@ Keep in mind that bots should respect the network's [rate limits](/docs/advanced
 
 Rate limits for [logging in](/docs/advanced-guides/rate-limits#hosted-account-pds-limits) are much lower than for [write operations like posting](/docs/advanced-guides/rate-limits#content-write-operations-per-account). Calling `agent.login()` multiple times in a short period may trigger rate limits. You only need to call `agent.login()` once per session to authenticate your agent, and can call `agent.post()` multiple times after that.
 
-You may want to persist your session to disk after logging in to avoid hitting login rate limits. You could do that by using helper functions like `readSessionFromDisk` and `writeSessionToDisk` with `agent.resumeSession()`:
+You may want to persist your session to disk after logging in to avoid hitting login rate limits. You could do that by implementing your own custom helper functions like `readSessionFromDisk` and `writeSessionToDisk` with `agent.resumeSession()`:
 
 ```ts
 const session = readSessionFromDisk()


### PR DESCRIPTION
In the "Bots" section under "Starter Templates", the docs say that you can use helper functions `readSessionFromDisk` and `writeSessionToDisk` in case you want to persist a session. From the way it was written, I thought that these functions was provided by the API, but from what I understand, we have to implement them ourselves. To avoid further misunderstandings in the future, I have updated the docs to be a little more clear.